### PR TITLE
Improve loops

### DIFF
--- a/src/main/java/com/slu/imagej/SpectralRTI_Toolkit.java
+++ b/src/main/java/com/slu/imagej/SpectralRTI_Toolkit.java
@@ -938,6 +938,8 @@ public class SpectralRTI_Toolkit implements Command {
                 WindowManager.getImage("Y").close(); //Don'e need this one.
                 ImagePlus cb = WindowManager.getImage("Cb");
                 ImagePlus cr = WindowManager.getImage("Cr");
+                cb.hide();
+                cr.hide();
                 logService.log().info("Set stack pieces...");
                 ImagePlus keptPieces = con.concatenate(cb, cr, true);
                 imp.close();
@@ -960,7 +962,7 @@ public class SpectralRTI_Toolkit implements Command {
                                 //WindowManager.getImage("Luminance").setRoi(normX, normY, normWidth, normHeight);
                                 imp.setRoi(normX, normY, normWidth, normHeight);
                                 IJ.run(imp, "Enhance Contrast...", "saturated=0.4");//Enhances image contrast by using either histogram stretching or histogram equalization.  Affects entire stack
-                                IJ.run("Select None");//Deactivates the selection in the active image.
+                                //IJ.run("Select None");//Deactivates the selection in the active image.
                             } 
                             else if (brightnessAdjustOption.equals("Yes, by multiplying all images by a fixed value")) {
                                 IJ.run(imp,"Multiply...", "value="+normalizationFixedValue+"");
@@ -971,13 +973,10 @@ public class SpectralRTI_Toolkit implements Command {
                         //This requires the images be showing.  Since this is in a loop, we really want to avoid this at all costs.
                         //imp.show();
                         //IJ.run("Concatenate...", "  title=[YCC] keep image1=Luminance image2=Cb image3=Cr image4=[-- None --]"); //Concatenates multiple images or stacks. Images with mismatching type and dimensions are omitted
-                        logService.log().info("What is imp? "+imp.getTitle());
-                        logService.log().info("What is keptPiece size? "+keptPieces.getStackSize());
+
                         ImagePlus stack = con.concatenate(imp, keptPieces, true);
                         stack.setTitle("YCC");
-                        logService.log().info("What is stack size 1? "+stack.getStackSize());
                         IJ.run(stack, "YCbCr stack to RGB", ""); //Converts a two or three slice stack into an RGB image, assuming that the slices are in R, G, B order. The stack must be 8-bit or 16-bit grayscale
-                        logService.log().info("What is stack size 2? "+stack.getStackSize());
                         //Save as jpeg
                         ImagePlus stackRGB = WindowManager.getImage("YCC - RGB");
                         stackRGB.hide();
@@ -1088,6 +1087,7 @@ public class SpectralRTI_Toolkit implements Command {
                             cr.close(); //Can this be closed??
                             //imp.show();
                             ImagePlus stack = con.concatenate(imp, keptPieces, true);
+                            stack.setTitle("YCC");
                             stack.hide();
                             IJ.run(stack, "YCbCr stack to RGB", "");
                             ImagePlus stackRGB = WindowManager.getImage("YCC - RGB");

--- a/src/main/java/com/slu/imagej/SpectralRTI_Toolkit.java
+++ b/src/main/java/com/slu/imagej/SpectralRTI_Toolkit.java
@@ -121,7 +121,7 @@ public class SpectralRTI_Toolkit implements Command {
         protected ImagePlus imp;
         
         /** The global ImgLib2 compatible Img type object to be used throughout.  Used with the ImgLib2 library. */
-        protected Img< FloatType > imglib2_img;       
+        //protected Img< FloatType > imglib2_img;       
         
         private Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         
@@ -742,7 +742,7 @@ public class SpectralRTI_Toolkit implements Command {
 		if (pcaHeight < 100){ //Looks like it was defined as 0 and never set or changed.  
                     File narrowbandNoGamma = new File(listOfNarrowbandCaptures[Math.round(listOfNarrowbandCaptures.length/2)].toString()); //projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+
                     imp = opener.openImage( narrowbandNoGamma.toString() );
-                    imglib2_img = ImagePlusAdapter.wrap( imp );
+                    //imglib2_img = ImagePlusAdapter.wrap( imp );
                     imp.setTitle("Preview");
                     //ImageJFunctions.show(imglib2_img, "Preview");
                     imp.show();
@@ -759,6 +759,7 @@ public class SpectralRTI_Toolkit implements Command {
                     pcaHeight = bounds.height;
                     pcaWidth = bounds.width;
                     imp.close();
+                    imp.flush();
 		}
             }
             /**
@@ -808,8 +809,9 @@ public class SpectralRTI_Toolkit implements Command {
                         IJ.error("There needs to be at least one image in the narrowband nogamma captures folder...");
                         throw new Throwable("There needs to be at least one image in the narrowband nogamma captures folder...");
                     }
-                    imglib2_img = ImagePlusAdapter.wrap( imp );
-                    ImageJFunctions.show(imglib2_img, "Preview");
+                    //imglib2_img = ImagePlusAdapter.wrap( imp );
+                    //ImageJFunctions.show(imglib2_img, "Preview");
+                    imp.show();
                     dWait = new WaitForUserDialog("Select area", "Draw a rectangle containing the colors of interest for PCA then click OK\n(hint: limit to object or smaller)");
                     dWait.show();
                     if(dWait.escPressed() || WindowManager.getImage("Preview").getRoi() == null){
@@ -822,7 +824,8 @@ public class SpectralRTI_Toolkit implements Command {
                     pcaY = bounds.y;
                     pcaHeight = bounds.height;
                     pcaWidth = bounds.width;
-                    WindowManager.getImage("Preview").close();
+                    imp.close();
+                    imp.flush();
                 }
             }
             if (csRtiDesired || csRakingDesired) { //interaction phase jhg 
@@ -836,8 +839,10 @@ public class SpectralRTI_Toolkit implements Command {
              */
             if (lpDesired) {
                 imp = opener.openImage(listOfHemisphereCaptures[20].toString());
-                imglib2_img = ImagePlusAdapter.wrap( imp );
-                ImageJFunctions.show(imglib2_img, "Preview");                
+                //imglib2_img = ImagePlusAdapter.wrap( imp );
+                //ImageJFunctions.show(imglib2_img, "Preview");   
+                imp.setTitle("Preview");
+                imp.show();
                 dWait = new WaitForUserDialog("Select ROI", "Draw a rectangle loosely around a reflective hemisphere and press Ok");
                 if(dWait.escPressed() || WindowManager.getImage("Preview").getRoi() == null){
                     //@userHitCancel
@@ -845,26 +850,30 @@ public class SpectralRTI_Toolkit implements Command {
                     throw new Throwable("You must draw a rectangle to continue!");
                 }
                 dWait.show();
-                bounds = WindowManager.getImage("Preview").getRoi().getBounds();
-                WindowManager.getImage("Preview").close();
+                bounds = imp.getRoi().getBounds();
+                imp.close();
+                imp.flush();
                 for(int i=0;i<listOfHemisphereCaptures.length;i++) {
                     if (listOfHemisphereCaptures[i].toString().endsWith("tiff") || listOfHemisphereCaptures[i].toString().endsWith("tif")) {
                         imp=opener.openImage(listOfHemisphereCaptures[i].toString());
-                        imglib2_img = ImagePlusAdapter.wrap( imp );
+                        //imglib2_img = ImagePlusAdapter.wrap( imp );
                         int extensionIndex = listOfHemisphereCaptures[i].getName().indexOf(".");
                         if (extensionIndex != -1)
                         {
                             filePath = projectDirectory+"LightPositionData"+File.separator+"jpeg-exports"+File.separator+listOfHemisphereCaptures[i].getName().substring(0, extensionIndex);
                         }
-                        ImageJFunctions.show(imglib2_img, "LightPosition");
-                        WindowManager.getImage("LightPosition").setRoi(0,0,(int)imglib2_img.dimension(3), (int)imglib2_img.dimension(4));
+                        imp.show();
+                        //ImageJFunctions.show(imglib2_img, "LightPosition");
+                        //WindowManager.getImage("LightPosition").setRoi(0,0,(int)imglib2_img.dimension(3), (int)imglib2_img.dimension(4));
+                        WindowManager.getImage("LightPosition").setRoi(bounds);
                         IJ.run("Crop"); //Crops the image or stack based on the current rectangular selection.
                         File jpegExportsFile = new File(projectDirectory+"LightPositionData"+File.separator+"jpeg-exports"+File.separator);
                         if (!light_position_dir.exists()) Files.createDirectory(light_position_dir.toPath());
                         if (!jpegExportsFile.exists()) Files.createDirectory(jpegExportsFile.toPath());
                         //Do we need to tell the users we created these directories?
                         IJ.saveAs("jpeg",filePath+".jpg"); //Use this submenu to save the active image in TIFF, GIF, JPEG, or format
-                        WindowManager.getImage("LightPosition").close();
+                        imp.close();
+                        imp.flush();
                     }
                 }
                 IJ.showMessageWithCancel("Use RTI Builder to Create LP File","Please use RTI Builder to create an LP file based on the reflective hemisphere detail images in\n"+projectDirectory+"LightPositionData"+File.separator+"\nPress cancel to discontinue Spectral RTI Toolkit or Ok to continue with other tasks after the lp file has been created.");
@@ -924,10 +933,11 @@ public class SpectralRTI_Toolkit implements Command {
 		}
 		//integration
                 imp = opener.openImage( accurateColorSource.toString() );
-                imglib2_img = ImagePlusAdapter.wrap( imp );
+                //imglib2_img = ImagePlusAdapter.wrap( imp );
 		if (imp.getBitDepth() == 8) {
                     IJ.run(imp,"RGB Color","");
                     imp.close();
+                    imp.flush();
                     imp = WindowManager.getCurrentImage();
                     imp.setTitle("RGBtiff");
 		}
@@ -936,6 +946,7 @@ public class SpectralRTI_Toolkit implements Command {
                 
                 //Stack to Images will automatically cause windows to open in the interim.  For processing, it is best if they are hidden.
                 WindowManager.getImage("Y").close(); //Don'e need this one.
+                WindowManager.getImage("Y").flush(); //Don'e need this one.
                 ImagePlus cb = WindowManager.getImage("Cb");
                 ImagePlus cr = WindowManager.getImage("Cr");
                 cb.hide();
@@ -943,6 +954,7 @@ public class SpectralRTI_Toolkit implements Command {
                 logService.log().info("Set stack pieces...");
                 ImagePlus keptPieces = con.concatenate(cb, cr, true);
                 imp.close();
+                imp.flush();
 		/**
                  *Luminance from hemisphere captures
                  */
@@ -953,7 +965,7 @@ public class SpectralRTI_Toolkit implements Command {
                          *@see better to trim list at the beginning so that array.length can be used in lp file
                          */
                         imp = opener.openImage( listOfHemisphereCaptures[i].toString() );
-                        imglib2_img = ImagePlusAdapter.wrap( imp );
+                        //imglib2_img = ImagePlusAdapter.wrap( imp );
                         imp.setTitle("Luminance");
                         // it would be better to crop early in the process, especially before reducing to 8-bit and jpeg compression
                         // normalize
@@ -989,21 +1001,28 @@ public class SpectralRTI_Toolkit implements Command {
                             filePath = projectDirectory+"AccurateColorRTI"+File.separator+"AccurateColor_"+simpleName2+simpleName3;
                             simpleImageName = "AccurateColor_"+simpleName2+simpleName3;
                         }
+                        
                         noClobber(filePath+".jpg");
                         IJ.saveAs(stackRGB, "jpeg", filePath+".jpg");
                         stackRGB.close();
-                        //WindowManager.getImage(simpleImageName+".jpg").close();
-                        //WindowManager.getImage("YCC").close();
+                        stackRGB.flush();
+                        //WindowManager.getImage(simpleImageName+".jpg").flush();
+                        //WindowManager.getImage("YCC").flush();
                         imp.changes=false;
-                        imp.close();          
+                        imp.close();
+                        imp.flush();   
                         stack.close();
+                        stack.flush();
                     }
 		}
-                //WindowManager.getImage("Cb").close();
-                //WindowManager.getImage("Cr").close();    
+                //WindowManager.getImage("Cb").flush();
+                //WindowManager.getImage("Cr").flush();    
                 cb.close();
+                cb.flush();
                 cr.close();
+                cr.flush();
                 keptPieces.close();
+                keptPieces.flush();
                 createLpFile("AccurateColor", projectDirectory); 
                 WindowManager.closeAllWindows(); // IS this needed?
 		runFitter("AccurateColor");
@@ -1011,7 +1030,7 @@ public class SpectralRTI_Toolkit implements Command {
             if (acRakingDesired) {
 //                logService.log().info("Raking.  Get numbering right.");
                 imp = opener.openImage( accurateColorSource.toString() ); 
-                imglib2_img = ImagePlusAdapter.wrap( imp );
+                //imglib2_img = ImagePlusAdapter.wrap( imp );
                 imp.setTitle("RGBtiff");
 		if (imp.getBitDepth() == 8) {
                     IJ.run(imp,"RGB Color","");
@@ -1027,8 +1046,10 @@ public class SpectralRTI_Toolkit implements Command {
 		IJ.run(imp, "RGB to YCbCr stack", "");
 		IJ.run("Stack to Images"); //Converts the slices in the current stack to separate image windows.
                 WindowManager.getImage("Y").close();
+                WindowManager.getImage("Y").flush();
                 imp.changes = false;
                 imp.close();
+                imp.flush();
                 ImagePlus cb = WindowManager.getImage("Cb");
                 ImagePlus cr = WindowManager.getImage("Cr");
                 cb.hide();
@@ -1049,6 +1070,7 @@ public class SpectralRTI_Toolkit implements Command {
                     //IJ.run("Concatenate...", "  title=[YCC] keep image1=TransmissiveLuminance image2=Cb image3=Cr image4=[-- None --]");
                     imp.changes=false;
                     imp.close();
+                    imp.flush();
                     IJ.run(stack, "YCbCr stack to RGB", "");
                     ImagePlus stackRGB = WindowManager.getImage("YCC - RGB");
                     stackRGB.hide();
@@ -1058,9 +1080,11 @@ public class SpectralRTI_Toolkit implements Command {
                     toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ac_Tx.tiff");
                     Files.deleteIfExists(toDelete.toPath());   
                     stack.close();
+                    stack.flush();
                     stackRGB.close();
-                    //WindowManager.getImage("YCC - RGB").close();
-                   // WindowManager.getImage("YCC").close();
+                    stackRGB.flush();
+                    //WindowManager.getImage("YCC - RGB").flush();
+                   // WindowManager.getImage("YCC").flush();
 		}
 		//Luminance from hemisphere captures
 		for(int i=0;i<listOfHemisphereCaptures.length;i++) {
@@ -1071,7 +1095,7 @@ public class SpectralRTI_Toolkit implements Command {
                         if (listOfRakingDirections.get(i)) {
                             imp = opener.openImage( listOfHemisphereCaptures[i].toString() );
                             imp.setTitle("Luminance");
-                            imglib2_img = ImagePlusAdapter.wrap(imp);
+                            //imglib2_img = ImagePlusAdapter.wrap(imp);
                             if (brightnessAdjustOption.equals("Yes, by normalizing each image to a selected area")) {
                                 imp.setRoi(normX, normY, normWidth, normHeight);
                                 IJ.run(imp, "Enhance Contrast...", "saturated=0.4");
@@ -1083,8 +1107,10 @@ public class SpectralRTI_Toolkit implements Command {
                             //IJ.run("Concatenate...", "title=[YCC] keep image1=Luminance image2=Cb image3=Cr image4=[-- None --]");
                             logService.log().info("Set stack pieces...");
                             ImagePlus keptPieces = con.concatenate(cb, cr, true);
-                            cb.close(); //Can this be closed??
-                            cr.close(); //Can this be closed??
+                            cb.close();
+                            cb.flush(); //Can this be closed??
+                            cr.close();
+                            cr.flush(); //Can this be closed??
                             //imp.show();
                             ImagePlus stack = con.concatenate(imp, keptPieces, true);
                             stack.setTitle("YCC");
@@ -1094,6 +1120,7 @@ public class SpectralRTI_Toolkit implements Command {
                             stackRGB.hide();
                             imp.changes = false;
                             imp.close();
+                            imp.flush();
                             //logService.log().info("I am making position numbers for these images.  The position number for this static raking is "+(i));
                             //a 00 position number was saved at the beginning
                             positionNumber = IJ.pad(i+1, 2).toString();
@@ -1102,16 +1129,20 @@ public class SpectralRTI_Toolkit implements Command {
                             IJ.save(stackRGB, projectDirectory+"StaticRaking"+File.separator+projectName+"_Ac_"+positionNumber+".tiff");
                             createJp2(projectName+"_Ac_"+positionNumber, projectDirectory);
                             toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ac_"+positionNumber+".tiff");
-                            Files.deleteIfExists(toDelete.toPath());     
+                            Files.deleteIfExists(toDelete.toPath());   
                             stack.close();
+                            stack.flush();
                             stackRGB.close();
-//                            WindowManager.getImage("YCC - RGB").close();
-//                            WindowManager.getImage("YCC").close(); 
+                            stackRGB.flush();
+//                            WindowManager.getImage("YCC - RGB").flush();
+//                            WindowManager.getImage("YCC").flush(); 
                         }
                     }
 		}
                 cb.close();
+                cb.flush();
                 cr.close();
+                cr.flush();
                 //WindowManager.closeAllWindows(); //Is this needed?
             }
             IJ.run("Collect Garbage");
@@ -1127,15 +1158,16 @@ public class SpectralRTI_Toolkit implements Command {
 		for (int i=1;i<redNarrowbands.length;i++) {
                     redStringList = redStringList+"|"+redNarrowbands[i].toString();
 		}
-                logService.log().info("What is red string list");
-                logService.log().info(redStringList);
-                ImagePlus redStacker = FolderOpener.open(projectDirectory+"Captures-Narrowband-NoGamma"+File.separator, "file=("+redStringList+") sort");
-		//IJ.run("Image Sequence...", "title=[RedStack] open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" file=("+redStringList+") sort"); 
+                //ImagePlus redStacker = FolderOpener.open(projectDirectory+"Captures-Narrowband-NoGamma"+File.separator, "file=("+redStringList+") sort"); //This only opens the folder, cant pick and choose
+		IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" file=("+redStringList+") sort"); 
+                ImagePlus redStacker = WindowManager.getImage("Captures-Narrowband-NoGamma");
                 //Opens a series of images in a chosen folder as a stack. Images may have different dimensions and can be of any format supported by ImageJ              
                 //ImagePlus redStacker = WindowManager.getImage("Captures-Narrowband-NoGamma");
                 redStacker.setTitle("RedStack");
+                logService.log().info("There are "+redStacker.getStackSize()+" images in the RED STACK");
                 redStacker.hide();
                 
+
                 //WindowManager.getImage("Captures-Narrowband-NoGamma").setTitle("RedStack");
                
                 //YIKES
@@ -1149,14 +1181,18 @@ public class SpectralRTI_Toolkit implements Command {
                 }
                 redStacker.setRoi(pcaX,pcaY,pcaWidth, pcaHeight); 
                 //WindowManager.getImage("RedStack").setRoi(pcaX,pcaY,pcaWidth, pcaHeight); 
+                logService.log().info("PCA on red stack");
 		IJ.run(redStacker,"PCA ", ""); 
                 ImagePlus pca_redStacker = WindowManager.getImage("PCA of RedStack");
                 pca_redStacker.hide();
-		IJ.run( pca_redStacker,"Slice Keeper", "first=1 last=1 increment=1");               
+		IJ.run( pca_redStacker,"Slice Keeper", "first=1 last=1 increment=1");      
                 WindowManager.getImage("Eigenvalue spectrum of RedStack").close();
                 redStacker.changes=false;
                 redStacker.close();
+                redStacker.flush();
                 pca_redStacker.close();
+                pca_redStacker.flush();
+                
                 ImagePlus kept_pcaRedStacker = WindowManager.getImage("PCA of RedStack kept stack");
                 kept_pcaRedStacker.hide();
                 //WindowManager.getWindow("PCA of RedStack kept stack").toFront();
@@ -1164,8 +1200,6 @@ public class SpectralRTI_Toolkit implements Command {
                 kept_pcaRedStacker.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); // questionable
 		IJ.run(kept_pcaRedStacker,"Enhance Contrast...", "saturated=0.4 normalize");
 		IJ.run(kept_pcaRedStacker, "8-bit", "");
-                
-                
                 
 		//Green
 		String greenStringList = greenNarrowbands[0].toString();  //might be an array to string function somewhere to do this more elegantly
@@ -1180,19 +1214,24 @@ public class SpectralRTI_Toolkit implements Command {
 		}
                 logService.log().info("What is greenStringList");
                 logService.log().info(greenStringList);
-                ImagePlus greenStacker = FolderOpener.open(projectDirectory+"Captures-Narrowband-NoGamma"+File.separator, "file=("+greenStringList+") sort");
-		//IJ.run("Image Sequence...", "title=[RedStack] open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" file=("+redStringList+") sort"); 
-		//IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" file=("+greenStringList+") sort");
+                //ImagePlus greenStacker = FolderOpener.open(projectDirectory+"Captures-Narrowband-NoGamma"+File.separator, "file=("+greenStringList+") sort");
+                IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" file=("+greenStringList+") sort"); 
+                ImagePlus greenStacker = WindowManager.getImage("Captures-Narrowband-NoGamma");
+                logService.log().info("There are "+greenStacker.getStackSize()+" images in the GREEN STACK");
+                greenStacker.hide();
                 greenStacker.setTitle("GreenStack");
                 greenStacker.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
+                logService.log().info("Run PCA on the GREEN STACK");
 		IJ.run(greenStacker,"PCA ", ""); 
                 ImagePlus pca_greenStacker = WindowManager.getImage("PCA of GreenStack");
                 pca_greenStacker.hide();
-		IJ.run(WindowManager.getImage("PCA of GreenStack"),"Slice Keeper", "first=1 last=1 increment=1");
+		IJ.run(pca_greenStacker,"Slice Keeper", "first=1 last=1 increment=1");
                 WindowManager.getImage("Eigenvalue spectrum of GreenStack").close();
                 greenStacker.changes=false;
                 greenStacker.close();
-                WindowManager.getImage("PCA of GreenStack").close();
+                greenStacker.flush();
+                pca_greenStacker.close();
+                pca_greenStacker.flush();
                 ImagePlus kept_pcaGreenStacker = WindowManager.getImage("PCA of GreenStack kept stack");
                 kept_pcaGreenStacker.hide();
                 //WindowManager.getWindow("PCA of GreenStack kept stack").toFront();
@@ -1200,9 +1239,8 @@ public class SpectralRTI_Toolkit implements Command {
                 kept_pcaGreenStacker.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
 		IJ.run(kept_pcaGreenStacker, "Enhance Contrast...", "saturated=0.4 normalize");
 		IJ.run(kept_pcaGreenStacker, "8-bit", "");
-                
-		
-//Blue
+               		
+                //Blue
 		String blueStringList = blueNarrowbands[0].toString();  //might be an array to string function somewhere to do this more elegantly
                 if(blueNarrowbands.length == 1){
                     //Yikes double check this doesnt break anything.  If it does, the user must provide at least 2 selections.  
@@ -1215,11 +1253,14 @@ public class SpectralRTI_Toolkit implements Command {
 		}
                 logService.log().info("What is blueStringList");
                 logService.log().info(blueStringList);
-                ImagePlus blueStacker = FolderOpener.open(projectDirectory+"Captures-Narrowband-NoGamma"+File.separator, "file=("+blueStringList+") sort");
+                //ImagePlus blueStacker = FolderOpener.open(projectDirectory+"Captures-Narrowband-NoGamma"+File.separator, "file=("+blueStringList+") sort");
+                IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" file=("+blueStringList+") sort");
+                ImagePlus blueStacker = WindowManager.getImage("Captures-Narrowband-NoGamma");
+                logService.log().info("There are "+blueStacker.getStackSize()+" images in the BLUE STACK");
                 blueStacker.hide();
-		//IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" file=("+blueStringList+") sort");
                 blueStacker.setTitle("BlueStack");
                 blueStacker.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
+                logService.log().info("Run PCA on the BLUE STACK");
 		IJ.run(blueStacker,"PCA ", ""); 
                 ImagePlus pca_blueStacker = WindowManager.getImage("PCA of BlueStack");
                 pca_blueStacker.hide();
@@ -1227,7 +1268,9 @@ public class SpectralRTI_Toolkit implements Command {
                 WindowManager.getImage("Eigenvalue spectrum of BlueStack").close();
                 blueStacker.changes = false;
                 blueStacker.close();
+                blueStacker.flush();
                 pca_blueStacker.close();
+                pca_blueStacker.flush();
                 ImagePlus kept_pcaBlueStacker =  WindowManager.getImage("PCA of BlueStack kept stack");
                 kept_pcaBlueStacker.hide();
                 kept_pcaBlueStacker.setTitle("B");
@@ -1235,38 +1278,51 @@ public class SpectralRTI_Toolkit implements Command {
 		IJ.run(kept_pcaBlueStacker, "Enhance Contrast...", "saturated=0.4 normalize");
 		IJ.run(kept_pcaBlueStacker, "8-bit", "");  
                 //imp.show();
-                ImagePlus stack = Concatenator.run(imp, kept_pcaRedStacker, kept_pcaBlueStacker, kept_pcaGreenStacker);
+                ImagePlus stack = Concatenator.run(kept_pcaRedStacker, kept_pcaBlueStacker, kept_pcaGreenStacker);
                 stack.setTitle("Stack");
                 stack.hide();
+                kept_pcaRedStacker.close();
+                kept_pcaRedStacker.flush();
+                kept_pcaBlueStacker.close();
+                kept_pcaBlueStacker.flush();
+                kept_pcaGreenStacker.close();
+                kept_pcaGreenStacker.flush();
 		//IJ.run("Concatenate...", "  title=[Stack] image1=R image2=G image3=B image4=[-- None --]");
                 //RGB stack of black and white
 		IJ.run(stack, "Stack to RGB", "");
-                ImagePlus stackRGB = WindowManager.getImage("Stack - RGB");
+                ImagePlus stackRGB = WindowManager.getImage("Stack (RGB)");
                 stackRGB.hide();
-                stack.hide();
+                stack.close();
+                stack.flush();
                 //RGB image of color.  Why isn't it color?
-                //WindowManager.getImage("Stack").close();
+                //WindowManager.getImage("Stack").flush();
 		//create extended spectrum static diffuse
 		if (xsRakingDesired){
                     noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_Xs_00"+".tiff");
-                    IJ.save(stack, projectDirectory+"StaticRaking"+File.separator+projectName+"_Xs_00"+".tiff");
+                    IJ.save(stackRGB, projectDirectory+"StaticRaking"+File.separator+projectName+"_Xs_00"+".tiff");
                     createJp2(projectName+"_Xs_00", projectDirectory); 
                     toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_Xs_00"+".tiff");
                     Files.deleteIfExists(toDelete.toPath());
 		}
-		IJ.run(stack, "RGB to YCbCr stack", "");
-		IJ.run(stack, "Stack to Images", "");
+		IJ.run(stackRGB, "RGB to YCbCr stack", "");
+                stackRGB.close();
+                stackRGB.flush();
+                ImagePlus YcbCrStack = WindowManager.getImage("Stack - YCbCr");
+                YcbCrStack.hide();
+		IJ.run(YcbCrStack, "Stack to Images", "");
+                YcbCrStack.close();
+                YcbCrStack.flush();
                 WindowManager.getImage("Y").close();
-                stack.close();
                 ImagePlus cb = WindowManager.getImage("Cb");
                 ImagePlus cr = WindowManager.getImage("Cr");
+               
                 cb.hide();
                 cr.hide();
                 ImagePlus keptPieces = con.concatenate(cb, cr, true);
                 logService.log().info("What is transmissive source "+transmissiveSource);
 		if (!transmissiveSource.equals("")){
                     imp = opener.openImage( transmissiveSource );
-                    imglib2_img = ImagePlusAdapter.wrap( imp );
+                    //imglib2_img = ImagePlusAdapter.wrap( imp );
                     imp.setTitle("TransmissiveLuminance");
                     IJ.run(imp, "8-bit", "");
                     //imp.show();
@@ -1280,14 +1336,17 @@ public class SpectralRTI_Toolkit implements Command {
                     stackRGB2.hide();
                     imp.changes=false;
                     imp.close();
+                    imp.flush();
                     noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_Xs_Tx.tiff");
                     IJ.save(stackRGB2, projectDirectory+"StaticRaking"+File.separator+projectName+"_Xs_Tx.tiff");
                     createJp2(projectName+"_Xs_Tx", projectDirectory);
                     toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_Xs_Tx.tiff");
                     Files.deleteIfExists(toDelete.toPath()); 
                     stack2.close();
-                    stackRGB2.clone();
-                    //WindowManager.getImage("YCC").close();
+                    stack2.flush();
+                    stackRGB2.close();
+                    stackRGB2.flush();
+                    //WindowManager.getImage("YCC").flush();
 		}
 		if (xsRtiDesired) {
                     if (!extended_spectrum_dir.exists()) {
@@ -1298,13 +1357,13 @@ public class SpectralRTI_Toolkit implements Command {
 		for(int i=0;i<listOfHemisphereCaptures.length;i++){
                     if (xsRtiDesired) {
                         imp = opener.openImage( listOfHemisphereCaptures[i].toString() );
-                        imglib2_img = ImagePlusAdapter.wrap( imp );
+                        //imglib2_img = ImagePlusAdapter.wrap( imp );
                         imp.setTitle("Luminance");
                         if (brightnessAdjustApply.equals("RTI images also")) {
                             if (brightnessAdjustOption.equals("Yes, by normalizing each image to a selected area")) {
-                                imp.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
+                                imp.setRoi(pcaX,pcaY,pcaWidth,pcaHeight);
                                 IJ.run(imp,"Enhance Contrast...", "saturated=0.4");
-                                IJ.run("Select None");
+                                //IJ.run("Select None");
                             } 
                             else if (brightnessAdjustOption.equals("Yes, by multiplying all images by a fixed value")) {
                                 IJ.run(imp, "Multiply...", "value="+normalizationFixedValue+"");
@@ -1330,21 +1389,23 @@ public class SpectralRTI_Toolkit implements Command {
                         noClobber(filePath+".jpg");
                         IJ.saveAs(stackRGB2, "jpeg",filePath+".jpg");
                         stack3.close();
+                        stack3.flush();
                         imp.changes = false;
                         imp.close();
+                        imp.flush();
                         stackRGB2.close();
-                        stack3.close();
-                        //WindowManager.getImage(simpleImageName+".jpg").close();
+                        stackRGB2.flush();
+                        //WindowManager.getImage(simpleImageName+".jpg").flush();
                     }
                     if (xsRakingDesired) {
                         if (listOfRakingDirections.get(i)) {
                             imp = opener.openImage( listOfHemisphereCaptures[i].toString() );
-                            imglib2_img = ImagePlusAdapter.wrap( imp );
+                            //imglib2_img = ImagePlusAdapter.wrap( imp );
                             imp.setTitle("Luminance");
                             if (brightnessAdjustOption.equals("Yes, by normalizing each image to a selected area")) {
                                 imp.setRoi(normX,normY,normWidth,normHeight); 
                                 IJ.run(imp, "Enhance Contrast...", "saturated=0.4");
-                                IJ.run("Select None");
+                                //IJ.run("Select None");
                             } 
                             else if (brightnessAdjustOption.equals("Yes, by multiplying all images by a fixed value")) {
                                 IJ.run(imp, "Multiply...", "value="+normalizationFixedValue+"");
@@ -1357,6 +1418,7 @@ public class SpectralRTI_Toolkit implements Command {
                             //IJ.run("Concatenate...", "  title=[YCC] keep image1=Luminance image2=Cb image3=Cr image4=[-- None --]");
                             imp.changes = false;
                             imp.close();
+                            imp.flush();
                             IJ.run(stack4, "YCbCr stack to RGB", "");
                             ImagePlus stackRGB3 = WindowManager.getImage("YCC - RGB");
                             stackRGB3.hide();
@@ -1367,14 +1429,18 @@ public class SpectralRTI_Toolkit implements Command {
                             toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_Xs_"+positionNumber+".tiff");
                             Files.deleteIfExists(toDelete.toPath()); 
                             stack4.close();
+                            stack4.flush();
                             stackRGB3.close();
-//                            WindowManager.getImage("YCC").close();
-//                            WindowManager.getImage("YCC - RGB").close();
+                            stackRGB3.flush();
+//                            WindowManager.getImage("YCC").flush();
+//                            WindowManager.getImage("YCC - RGB").flush();
                         }
                     }
 		}
                 cb.close();
+                cb.flush();
                 cr.close();
+                cr.flush();
 		if (xsRtiDesired) {
                     createLpFile("ExtendedSpectrum", projectDirectory);
                     runFitter("ExtendedSpectrum");
@@ -1489,7 +1555,7 @@ public class SpectralRTI_Toolkit implements Command {
                     
                     if (!transmissiveSource.equals("")) {
                         imp = opener.openImage( transmissiveSource );
-                        imglib2_img = ImagePlusAdapter.wrap( imp );
+                        // = ImagePlusAdapter.wrap( imp );
                         imp.setTitle("TransmissiveLuminance");
                         IJ.run(imp, "8-bit", "");
                         imp.show();
@@ -1497,6 +1563,7 @@ public class SpectralRTI_Toolkit implements Command {
                         IJ.run("YCbCr stack to RGB");
                         imp.changes = false;
                         imp.close();
+                        imp.flush();
                         noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_Tx.tiff");
                         IJ.save(WindowManager.getImage("YCC - RGB"), projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_Tx.tiff");
                         createJp2(projectName+"_Ps_Tx", projectDirectory);
@@ -1516,7 +1583,7 @@ public class SpectralRTI_Toolkit implements Command {
 		for(int i=0;i<listOfHemisphereCaptures.length;i++) {
                     if (psRtiDesired||listOfRakingDirections.get(i)){ //YIKES double check on this
                         imp = opener.openImage( listOfHemisphereCaptures[i].toString() );
-                        imglib2_img = ImagePlusAdapter.wrap( imp );
+                        //imglib2_img = ImagePlusAdapter.wrap( imp );
                         imp.setTitle("Luminance");
                         int extensionIndex = listOfHemisphereCaptures[i].getName().indexOf(".");
                         IJ.run(imp, "Duplicate...", "title=EnhancedLuminance");
@@ -1582,6 +1649,7 @@ public class SpectralRTI_Toolkit implements Command {
                         imp.changes = false;
                         WindowManager.getImage("EnhancedLuminance").close();
                         imp.close();
+                        imp.flush();
                     }
 		}
                 WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack").changes = false;
@@ -1603,7 +1671,7 @@ public class SpectralRTI_Toolkit implements Command {
                     logService.log().info("A directory has been created for "+csProcessName+" RTI at "+projectDirectory+csProcessName+"RTI"+File.separator);
 		}
                 imp = opener.openImage(csSource);
-                imglib2_img = ImagePlusAdapter.wrap( imp );
+                //imglib2_img = ImagePlusAdapter.wrap( imp );
 		if ((imp.getImageStackSize() == 1)&&(imp.getBitDepth()<24)) {
                     if (csRakingDesired) {
                         noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_00"+".tiff");
@@ -1646,13 +1714,14 @@ public class SpectralRTI_Toolkit implements Command {
                 WindowManager.getImage("csSource").close();
 		if (!transmissiveSource.equals("")) {
                     imp = opener.openImage( transmissiveSource );
-                    imglib2_img = ImagePlusAdapter.wrap( imp );
+                    //imglib2_img = ImagePlusAdapter.wrap( imp );
                     IJ.run(imp, "8-bit", "");
                     imp.show();
                     IJ.run("Concatenate...", "  title=[YCC] keep image1=TransmissiveLuminance image2=Cb image3=Cr image4=[-- None --]");
                     IJ.run("YCbCr stack to RGB");
                     imp.changes = false;
                     imp.close();
+                    imp.flush();
                     noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_Tx.tiff");
                     IJ.save(WindowManager.getImage("YCC - RGB"), projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_Tx.tiff");
                     createJp2(projectName+"_"+csProcessName+"_Tx", projectDirectory);
@@ -1665,7 +1734,7 @@ public class SpectralRTI_Toolkit implements Command {
                     if (listOfHemisphereCaptures[i].toString().endsWith("tiff")|| listOfHemisphereCaptures[i].toString().endsWith("tif")) {
                         if ((csRtiDesired)|| listOfRakingDirections.get(i)) {
                             imp = opener.openImage( listOfHemisphereCaptures[i].toString() );
-                            imglib2_img = ImagePlusAdapter.wrap( imp );
+                            //imglib2_img = ImagePlusAdapter.wrap( imp );
                             int extensionIndex = listOfHemisphereCaptures[i].getName().indexOf(".");
                             if (extensionIndex != -1)
                             {
@@ -1719,7 +1788,7 @@ public class SpectralRTI_Toolkit implements Command {
                             WindowManager.getImage("EnhancedLuminance").changes = false;
                             imp.changes = false;
                             WindowManager.getImage("EnhancedLuminance").close();
-                            imp.close();
+                            imp.flush();
                         }
                     }
 		}
@@ -1886,7 +1955,7 @@ public class SpectralRTI_Toolkit implements Command {
             logService.log().warn(listOfHemisphereCaptures[Math.round(listOfHemisphereCaptures.length/2)].toString());
             END DEBUGGING */
             imp = opener.openImage( listOfHemisphereCaptures[Math.round(listOfHemisphereCaptures.length/2)].toString() );
-            imglib2_img = ImagePlusAdapter.wrap( imp );
+            //imglib2_img = ImagePlusAdapter.wrap( imp );
             imp.setTitle("Preview");
             //ImageJFunctions.show(imglib2_img, "Preview");
             imp.show();
@@ -1949,6 +2018,7 @@ public class SpectralRTI_Toolkit implements Command {
                 logService.log().warn("Brightness not modified");
             }
             imp.close();
+            imp.flush();
         } 
         
         /** 

--- a/src/main/java/com/slu/imagej/SpectralRTI_Toolkit.java
+++ b/src/main/java/com/slu/imagej/SpectralRTI_Toolkit.java
@@ -102,7 +102,6 @@ import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import java.awt.Dialog;
-import java.util.Collections;
 import javax.swing.BoxLayout;
 import javax.swing.JFrame;
 import org.apache.commons.io.comparator.NameFileComparator;
@@ -1449,44 +1448,70 @@ public class SpectralRTI_Toolkit implements Command {
             }
             if (psRtiDesired || psRakingDesired) {
                 File fluorescenceNoGamma = new File(projectDirectory+"Captures-Fluorescence-NoGamma"+File.separator);
+                ImagePlus flNoGamma;
+                ImagePlus flNarrowNoGammaStack;
+                ImagePlus narrowNoGamma;
+                ImagePlus narrowKeptPCA = new ImagePlus();
 		//option to create new ones based on narrowband captures and assumption that pc1 and pc2 are best
 		if (pcaMethod.equals("Generate and select using defaults")){
                     IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" sort");
+                    narrowNoGamma = WindowManager.getImage("Captures-Narrowband-NoGamma");
+                    narrowNoGamma.hide();
                     if (fluorescenceNoGamma.exists()) {
                         IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Fluorescence-NoGamma"+File.separator+" sort");
-                        IJ.run("Concatenate...", "  title=Captures-Narrowband-NoGamma image1=Captures-Narrowband-NoGamma image2=Captures-Fluorescence-NoGamma image3=[-- None --]");
+                        flNoGamma = WindowManager.getImage("Captures-Fluorescence-NoGamma");
+                        flNoGamma.hide();
+                        flNarrowNoGammaStack = con.concatenate(narrowNoGamma, flNoGamma, false);
+                        narrowNoGamma.flush();
+                        narrowNoGamma = flNarrowNoGammaStack;
+                        //IJ.run("Concatenate...", "  title=Captures-Narrowband-NoGamma image1=Captures-Narrowband-NoGamma image2=Captures-Fluorescence-NoGamma image3=[-- None --]");
                     }
                     else{
                         // ?
                     }
-                    WindowManager.getImage("Captures-Narrowband-NoGamma").setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
-                    IJ.run("PCA ");
+                    narrowNoGamma.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
+                    IJ.run(narrowNoGamma, "PCA ", "");
                     IJ.run(WindowManager.getImage("PCA of Captures-Narrowband-NoGamma"),"Slice Keeper", "first=2 last=3 increment=1");
                     WindowManager.getImage("Eigenvalue spectrum of Captures-Narrowband-NoGamma").close();
-                    WindowManager.getImage("Captures-Narrowband-NoGamma").changes = false;
-                    WindowManager.getImage("Captures-Narrowband-NoGamma").close();
+                    narrowNoGamma.changes = false;
+                    narrowNoGamma.flush();
+                    narrowNoGamma.close();
                     WindowManager.getImage("PCA of Captures-Narrowband-NoGamma").close();
-                    WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack").setActivated();
-                    WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack").setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
-                    IJ.run(WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack"), "Enhance Contrast...", "saturated=0.3 normalize update process_all");
-                    IJ.run(WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack"), "8-bit", "");
+                    ImagePlus keptNoGammaPCA = WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack");
+                    keptNoGammaPCA.hide();
+                    keptNoGammaPCA.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
+                    IJ.run(keptNoGammaPCA, "Enhance Contrast...", "saturated=0.3 normalize update process_all");
+                    IJ.run(keptNoGammaPCA, "8-bit", "");
+                    narrowKeptPCA = keptNoGammaPCA;
 		} 
                 else if (pcaMethod.equals("Generate and manually select two")) {
                     //option to create new ones and manually select (close all but two)
                     IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" sort");
+                    narrowNoGamma = WindowManager.getImage("Captures-Narrowband-NoGamma");
+                    narrowNoGamma.hide();
                     if (fluorescenceNoGamma.exists()) {
                         IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Fluorescence-NoGamma"+File.separator+" sort");
-                        IJ.run("Concatenate...", "  title=Captures-Narrowband-NoGamma image1=Captures-Narrowband-NoGamma image2=Captures-Fluorescence-NoGamma image3=[-- None --]");
-                    } 
-                    else {
+                        flNoGamma = WindowManager.getImage("Captures-Fluorescence-NoGamma");
+                        flNoGamma.hide();
+                        flNarrowNoGammaStack = con.concatenate(narrowNoGamma, flNoGamma, false);
+                        narrowNoGamma.flush();
+                        narrowNoGamma = flNarrowNoGammaStack;
+                        //IJ.run("Concatenate...", "  title=Captures-Narrowband-NoGamma image1=Captures-Narrowband-NoGamma image2=Captures-Fluorescence-NoGamma image3=[-- None --]");
+                    }
+                    else{
                         // ?
                     }
                     IJ.run("PCA ");
-                    WindowManager.getImage("PCA of Captures-Narrowband-NoGamma").setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
+                    narrowNoGamma.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
+                    IJ.run(narrowNoGamma, "PCA ", "");
+                    IJ.run(WindowManager.getImage("PCA of Captures-Narrowband-NoGamma"),"Slice Keeper", "first=2 last=3 increment=1");
                     WindowManager.getImage("Eigenvalue spectrum of Captures-Narrowband-NoGamma").close();
-                    WindowManager.getImage("Captures-Narrowband-NoGamma").changes = false;
-                    WindowManager.getImage("Captures-Narrowband-NoGamma").close();
-                    WindowManager.getImage("PCA of Captures-Narrowband-NoGamma").setActivated();
+                    narrowNoGamma.changes = false;
+                    narrowNoGamma.flush();
+                    narrowNoGamma.close();
+                    //WindowManager.getImage("PCA of Captures-Narrowband-NoGamma").close();
+                    ImagePlus noGammaPCA = WindowManager.getImage("PCA of Captures-Narrowband-NoGamma");
+                    noGammaPCA.show();
                     dWait = new WaitForUserDialog("Delete Slices", "Delete slices from the stack until two remain\n(Hint: Image > Stacks > Delete Slice)\nEnhance contrast as desired\nThen press Ok");
                     if(dWait.escPressed()){
                         //@userHitCancel
@@ -1494,9 +1519,11 @@ public class SpectralRTI_Toolkit implements Command {
                         throw new Throwable("You must delete until there are two slices to continue!");
                     }
                     dWait.show();
-                    WindowManager.getImage("PCA of Captures-Narrowband-NoGamma").setTitle("PCA of Captures-Narrowband-NoGamma kept stack");
-                    WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack").setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
-                    IJ.run(WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack"), "8-bit", "");
+                    noGammaPCA.hide();
+                    noGammaPCA.setTitle("PCA of Captures-Narrowband-NoGamma kept stack");
+                    noGammaPCA.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
+                    IJ.run(noGammaPCA, "8-bit", "");
+                    narrowKeptPCA = noGammaPCA;
 		/**
                  * @see option to use previously generated principal component images
                  */
@@ -1518,6 +1545,7 @@ public class SpectralRTI_Toolkit implements Command {
                         throw new Throwable("Open a pair of images or stack of two slices to continue!");
                     }
                     IJ.run(WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack"), "8-bit", "");
+                    narrowKeptPCA = WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack");
 		}
 		/**
                     * @see integrate pca pseudocolor with rti luminance
@@ -1526,51 +1554,68 @@ public class SpectralRTI_Toolkit implements Command {
                 logService.log().info("Process Part 2");
 		if (psRakingDesired){
                     IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Hemisphere-Gamma"+File.separator);
-                    IJ.run("Z Project...", "projection=Median");
-                    WindowManager.getImage("MED_Captures-Hemisphere-Gamma").setTitle("Luminance");
-                    WindowManager.getImage("Captures-Hemisphere-Gamma").changes = false;
-                    WindowManager.getImage("Captures-Hemisphere-Gamma").close();   
-                    WindowManager.getImage("Luminance").setActivated();
+                    narrowNoGamma = WindowManager.getImage("Captures-Narrowband-NoGamma");
+                    narrowNoGamma.hide();
+                    IJ.run(narrowNoGamma, "Z Project...", "projection=Median");
+                    narrowNoGamma.changes = false;
+                    narrowNoGamma.flush();
+                    narrowNoGamma.close();   
+                    ImagePlus luminance = WindowManager.getImage("MED_Captures-Hemisphere-Gamma");
+                    luminance.setTitle("Luminance");
+                    luminance.hide();
                     if (brightnessAdjustOption.equals("Yes, by normalizing each image to a selected area")) {
                         region = new RectangleOverlay();
-                        WindowManager.getImage("Luminance").setRoi(normX,normY,normWidth,normHeight); 
-                        IJ.run("Enhance Contrast...", "saturated=0.4");
-                        IJ.run("Select None");
+                        luminance.setRoi(normX,normY,normWidth,normHeight); 
+                        IJ.run(luminance, "Enhance Contrast...", "saturated=0.4");
+                        //IJ.run("Select None");
                     } 
                     else if (brightnessAdjustOption.equals("Yes, by multiplying all images by a fixed value")) {
-                        IJ.run("Multiply...", "value="+normalizationFixedValue+"");
+                        IJ.run(luminance, "Multiply...", "value="+normalizationFixedValue+"");
                     }
-                    IJ.run(WindowManager.getImage("Luminance"), "8-bit", "");
-                    IJ.run("Concatenate...", "  title=[YCC] keep image1=Luminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
-                    IJ.run("YCbCr stack to RGB");
+                    IJ.run(luminance, "8-bit", "");
+                    ImagePlus lumNarrowKeptStack = con.concatenate(luminance, narrowKeptPCA, true);
+                    lumNarrowKeptStack.setTitle("YCC");
+                    lumNarrowKeptStack.hide();
+                    //IJ.run("Concatenate...", "  title=[YCC] keep image1=Luminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
+                    IJ.run(lumNarrowKeptStack, "YCbCr stack to RGB", "");
+                    ImagePlus lumRGB = WindowManager.getImage("YCC - RGB");
+                    lumRGB.hide();
                     noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_00.tiff");
-                    IJ.save(WindowManager.getImage("YCC - RGB"), projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_00.tiff");
+                    IJ.save(lumRGB, projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_00.tiff");
                     createJp2(projectName+"_Ps_00", projectDirectory);
                     toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_00.tiff");
                     Files.deleteIfExists(toDelete.toPath());
-                    WindowManager.getImage("YCC - RGB").close();
-                    WindowManager.getImage("YCC").close();
-                    WindowManager.getImage("Luminance").changes = false;
-                    WindowManager.getImage("Luminance").close();
-                    
+                    lumRGB.flush();
+                    lumRGB.close();
+                    lumNarrowKeptStack.flush();
+                    lumNarrowKeptStack.close();
+                    luminance.changes = false;
+                    luminance.flush();
+                    luminance.close();
                     if (!transmissiveSource.equals("")) {
                         imp = opener.openImage( transmissiveSource );
                         // = ImagePlusAdapter.wrap( imp );
                         imp.setTitle("TransmissiveLuminance");
                         IJ.run(imp, "8-bit", "");
-                        imp.show();
-                        IJ.run("Concatenate...", "  title=[YCC] keep image1=TransmissiveLuminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
-                        IJ.run("YCbCr stack to RGB");
+                        //imp.show();
+                        ImagePlus transNarrowKeptStack = con.concatenate(imp, narrowKeptPCA, true);
+                        transNarrowKeptStack.setTitle("YCC");
+                        transNarrowKeptStack.hide();
+                        //IJ.run("Concatenate...", "  title=[YCC] keep image1=TransmissiveLuminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
+                        IJ.run(transNarrowKeptStack, "YCbCr stack to RGB", "");
+                        ImagePlus transRGB = WindowManager.getImage("YCC - RGB");
+                        transRGB.hide();
                         imp.changes = false;
                         imp.close();
                         imp.flush();
                         noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_Tx.tiff");
-                        IJ.save(WindowManager.getImage("YCC - RGB"), projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_Tx.tiff");
+                        IJ.save(transRGB, projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_Tx.tiff");
                         createJp2(projectName+"_Ps_Tx", projectDirectory);
                         toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_Tx.tiff");
                         Files.deleteIfExists(toDelete.toPath());
-                        WindowManager.getImage("YCC - RGB").close();
-                        WindowManager.getImage("YCC").close();
+                        transRGB.flush();
+                        transNarrowKeptStack.flush();
+                        transRGB.close();
                     }
 		}
 		if (psRtiDesired) {
@@ -1587,33 +1632,38 @@ public class SpectralRTI_Toolkit implements Command {
                         imp.setTitle("Luminance");
                         int extensionIndex = listOfHemisphereCaptures[i].getName().indexOf(".");
                         IJ.run(imp, "Duplicate...", "title=EnhancedLuminance");
-                        WindowManager.getImage("EnhancedLuminance").setActivated();
+                        ImagePlus enhancedLum = WindowManager.getImage("EnhancedLuminance");
+                        enhancedLum.hide();
                         if (brightnessAdjustOption.equals("Yes, by normalizing each image to a selected area")) {
-                            WindowManager.getImage("EnhancedLuminance").setRoi(normX,normY,normWidth,normHeight); 
-                            IJ.run(WindowManager.getImage("EnhancedLuminance"),"Enhance Contrast...", "saturated=0.4");
-                            IJ.run("Select None");
+                            enhancedLum.setRoi(normX,normY,normWidth,normHeight); 
+                            IJ.run(enhancedLum,"Enhance Contrast...", "saturated=0.4");
+                            //IJ.run("Select None");
                         } 
                         else if (brightnessAdjustOption.equals("Yes, by multiplying all images by a fixed value")) {
-                            IJ.run(WindowManager.getImage("EnhancedLuminance"),"Multiply...", "value="+normalizationFixedValue+"");
+                            IJ.run(enhancedLum,"Multiply...", "value="+normalizationFixedValue+"");
                         }
                         IJ.run(imp, "8-bit", "");
-                        IJ.run(WindowManager.getImage("EnhancedLuminance"), "8-bit", "");
+                        IJ.run(enhancedLum, "8-bit", "");
+                        ImagePlus enhancedNarrowKeptStack = con.concatenate(enhancedLum, narrowKeptPCA, true);
+                        enhancedNarrowKeptStack.setTitle("YCC");
+                        enhancedNarrowKeptStack.hide();
+                        IJ.run(enhancedNarrowKeptStack, "YCbCr stack to RGB", "");
+                        enhancedNarrowKeptStack.close();
+                        ImagePlus RGBImg = WindowManager.getImage("YCC - RGB");
+                        RGBImg.hide();
                         if (listOfRakingDirections.get(i)) { //Yikes double check on this.  I believe it conrtols whether or not a StaticRaking file is created but doesn't rely on psrakingDesired.
-                            IJ.run("Concatenate...", "  title=[YCC] keep image1=EnhancedLuminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
-                            IJ.run("YCbCr stack to RGB");
-                            WindowManager.getImage("YCC").close();
+                            //IJ.run("Concatenate...", "  title=[YCC] keep image1=EnhancedLuminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
+                            IJ.run(enhancedNarrowKeptStack, "YCbCr stack to RGB", "");
+                            enhancedNarrowKeptStack.flush();
+                            enhancedNarrowKeptStack.close();
                             positionNumber = IJ.pad(i+1, 2).toString();                          
                             noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_"+positionNumber+".tiff");
-                            IJ.save(WindowManager.getImage("YCC - RGB"), projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_"+positionNumber+".tiff");
-                            WindowManager.getImage("YCC - RGB").close();
+                            IJ.save(RGBImg, projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_"+positionNumber+".tiff");
                             createJp2(projectName+"_Ps_"+positionNumber, projectDirectory);
                             toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_Ps_"+positionNumber+".tiff");
                             Files.deleteIfExists(toDelete.toPath());
                         }
                         if ((psRtiDesired)&&(brightnessAdjustApply.equals("RTI images also"))){ 
-                            IJ.run("Concatenate...", "  title=[YCC] keep image1=EnhancedLuminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
-                            IJ.run("YCbCr stack to RGB");
-                            WindowManager.getImage("YCC").close();
                             extensionIndex = listOfHemisphereCaptures[i].getName().indexOf(".");
                             if (extensionIndex != -1)
                             {
@@ -1624,14 +1674,10 @@ public class SpectralRTI_Toolkit implements Command {
                                 simpleImageName = "PseudoColor_"+simpleName2+simpleName3;
                             }
                             noClobber(filePath+".jpg");
-                            IJ.saveAs("jpeg", filePath+".jpg");
+                            IJ.saveAs(RGBImg, "jpeg", filePath+".jpg");
                             WindowManager.getImage(simpleImageName+".jpg").close();
                         } 
                         else if (psRtiDesired) {
-                            //Was this supposed to be Enhanced Luminance or Luminance?
-                            IJ.run("Concatenate...", "  title=[YCC] keep image1=EnhancedLuminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
-                            IJ.run("YCbCr stack to RGB");
-                            WindowManager.getImage("YCC").close();
                             extensionIndex = listOfHemisphereCaptures[i].getName().indexOf(".");
                             if (extensionIndex != -1)
                             {
@@ -1642,19 +1688,22 @@ public class SpectralRTI_Toolkit implements Command {
                                 simpleImageName = "PseudoColor_"+simpleName2+simpleName3;
                             }
                             noClobber(filePath+".jpg");
-                            IJ.saveAs("jpeg", filePath+".jpg");
+                            IJ.saveAs(RGBImg, "jpeg", filePath+".jpg");
                             WindowManager.getImage(simpleImageName+".jpg").close();
                         }
-                        WindowManager.getImage("EnhancedLuminance").changes = false;
+                        enhancedLum.changes = false;
                         imp.changes = false;
-                        WindowManager.getImage("EnhancedLuminance").close();
+                        enhancedLum.flush();
+                        enhancedLum.close();
                         imp.close();
                         imp.flush();
+                        RGBImg.flush();
+                        RGBImg.close();
                     }
 		}
-                WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack").changes = false;
-                WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack").close();
-                System.gc();
+                narrowKeptPCA.changes = false;
+                narrowKeptPCA.flush();
+                narrowKeptPCA.close();
 		if (psRtiDesired) {
                     createLpFile("Pseudocolor", projectDirectory);
                     runFitter("Pseudocolor");
@@ -1666,6 +1715,8 @@ public class SpectralRTI_Toolkit implements Command {
 		String[] csParents = csSource.split(File.separator);
 		String csProcessName = csParents[csParents.length-2];
                 File csProcessFile = new File(projectDirectory+csProcessName+"RTI"+File.separator);
+                ImagePlus cb = new ImagePlus();
+                ImagePlus cr = new ImagePlus();
 		if (!csProcessFile.exists()) {
                     Files.createDirectory(csProcessFile.toPath());
                     logService.log().info("A directory has been created for "+csProcessName+" RTI at "+projectDirectory+csProcessName+"RTI"+File.separator);
@@ -1683,12 +1734,21 @@ public class SpectralRTI_Toolkit implements Command {
                     IJ.run(imp, "8-bit", "");
                     IJ.run(imp, "Duplicate...", "title=Cb");
                     IJ.run(imp, "Duplicate...", "title=Cr");
+                    cb = WindowManager.getImage("Cb");
+                    cr = WindowManager.getImage("Cr");
+                    cb.hide();
+                    cr.hide();
 		} 
                 else if (imp.getImageStackSize() == 2) {
                     IJ.run(imp, "8-bit", "");
                     IJ.run(imp, "Stack to Images", "");
-                    WindowManager.getImage(1).setTitle("Cb");
-                    WindowManager.getImage(2).setTitle("Cr");
+                    cb = WindowManager.getImage(1);
+                    cr = WindowManager.getImage(2);
+                    cb.setTitle("Cb");
+                    cr.setTitle("Cr");
+                    cb.hide();
+                    cr.hide();
+
 		} 
                 else if ((imp.getImageStackSize() > 2)||(imp.getBitDepth()==24)){
                     if (imp.getImageStackSize() > 3) {
@@ -1710,25 +1770,36 @@ public class SpectralRTI_Toolkit implements Command {
                     IJ.run("8-bit");
                     IJ.run("Stack to Images");
                     WindowManager.getImage("Y").close();
+                    cb = WindowManager.getImage("Cb");
+                    cr = WindowManager.getImage("Cr");
+                    cb.hide();
+                    cr.hide();
 		}
                 WindowManager.getImage("csSource").close();
 		if (!transmissiveSource.equals("")) {
                     imp = opener.openImage( transmissiveSource );
                     //imglib2_img = ImagePlusAdapter.wrap( imp );
                     IJ.run(imp, "8-bit", "");
-                    imp.show();
-                    IJ.run("Concatenate...", "  title=[YCC] keep image1=TransmissiveLuminance image2=Cb image3=Cr image4=[-- None --]");
-                    IJ.run("YCbCr stack to RGB");
+                    //imp.show();
+                    ImagePlus piece = con.concatenate(cb, cr, true);
+                    ImagePlus stack = con.concatenate(imp, piece, true);
+                    stack.setTitle("YCC");
+                    //IJ.run("Concatenate...", "  title=[YCC] keep image1=TransmissiveLuminance image2=Cb image3=Cr image4=[-- None --]");
+                    IJ.run(stack, "YCbCr stack to RGB", "");
+                    ImagePlus RGBImage = WindowManager.getImage("YCC - RGB");
+                    RGBImage.hide();
                     imp.changes = false;
                     imp.close();
                     imp.flush();
                     noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_Tx.tiff");
-                    IJ.save(WindowManager.getImage("YCC - RGB"), projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_Tx.tiff");
+                    IJ.save(RGBImage, projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_Tx.tiff");
                     createJp2(projectName+"_"+csProcessName+"_Tx", projectDirectory);
                     toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_Tx.tiff");
                     Files.deleteIfExists(toDelete.toPath());
-                    WindowManager.getImage("YCC - RGB").close();
-                    WindowManager.getImage("YCC").close();
+                    RGBImage.flush();
+                    RGBImage.close();
+                    stack.flush();
+                    stack.close();
 		}
 		for(int i=0;i<listOfHemisphereCaptures.length;i++) {
                     if (listOfHemisphereCaptures[i].toString().endsWith("tiff")|| listOfHemisphereCaptures[i].toString().endsWith("tif")) {
@@ -1745,55 +1816,62 @@ public class SpectralRTI_Toolkit implements Command {
                                 simpleImageName = "CustomSource_"+simpleName2+simpleName3;
                             }
                             noClobber(filePath+".jpg");
-                            IJ.saveAs("jpeg", filePath+".jpg");
+                            IJ.saveAs(imp, "jpeg", filePath+".jpg");
                             IJ.run(imp, "Duplicate...", "title=EnhancedLuminance");
+                            ImagePlus enhancedLum = WindowManager.getImage("EnhancedLuminance");
+                            enhancedLum.hide();
                             if (brightnessAdjustOption.equals("Yes, by normalizing each image to a selected area")) {
                                 region = new RectangleOverlay();
                                 imp.setRoi(normX,normY,normWidth,normHeight); 
-                                IJ.run(WindowManager.getImage("EnhancedLuminance"),"Enhance Contrast...", "saturated=0.4");
-                                IJ.run("Select None");
+                                IJ.run(enhancedLum,"Enhance Contrast...", "saturated=0.4");
+                                //IJ.run("Select None");
                             } else if (brightnessAdjustOption.equals("Yes, by multiplying all images by a fixed value")) {
-                                IJ.run(WindowManager.getImage("EnhancedLuminance"),"Multiply...", "value="+normalizationFixedValue+"");
+                                IJ.run(enhancedLum,"Multiply...", "value="+normalizationFixedValue+"");
                             }
-                            IJ.run(WindowManager.getImage("Luminance"), "8-bit", "");
-                            WindowManager.getWindow("EnhancedLuminance").toFront();
-                            IJ.run(WindowManager.getImage("EnhancedLuminance"), "8-bit", "");
+                            IJ.run(imp, "8-bit", "");
+                            IJ.run(enhancedLum, "8-bit", "");
+                            ImagePlus piece = con.concatenate(cb, cr, true);
+                            ImagePlus stack = con.concatenate(imp, piece, true);
+                            stack.setTitle("YCC");
+                            //IJ.run("Concatenate...", "  title=[YCC] keep image1=TransmissiveLuminance image2=Cb image3=Cr image4=[-- None --]");
+                            IJ.run(stack, "YCbCr stack to RGB", "");
+                            ImagePlus RGBImage = WindowManager.getImage("YCC - RGB");
+                            RGBImage.hide();
+                            //IJ.run("Concatenate...", "  title=[YCC] keep image1=EnhancedLuminance image2=Cb image3=Cr image4=[-- None --]");
+                            stack.flush();
+                            stack.close();
                             if (listOfRakingDirections.get(i)){
-                                IJ.run("Concatenate...", "  title=[YCC] keep image1=EnhancedLuminance image2=Cb image3=Cr image4=[-- None --]");
-                                IJ.run("YCbCr stack to RGB");
-                                WindowManager.getImage("YCC").close();
                                 positionNumber = IJ.pad(i+1, 2).toString();
                                 noClobber(projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_"+positionNumber+".tiff");
-                                IJ.save(WindowManager.getImage("YCC - RGB"),projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_"+positionNumber+".tiff");
-                                WindowManager.getImage("YCC - RGB").close();
+                                IJ.save(RGBImage,projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_"+positionNumber+".tiff");
+                                RGBImage.flush();
+                                RGBImage.close();
                                 createJp2(projectName+"_"+csProcessName+"_"+positionNumber, projectDirectory);
                                 toDelete = new File(projectDirectory+"StaticRaking"+File.separator+projectName+"_"+csProcessName+"_"+positionNumber+".tiff");
                                 Files.deleteIfExists(toDelete.toPath());
                             }
                             if ((csRtiDesired)&&(brightnessAdjustApply.equals("RTI images also"))){
-                                IJ.run("Concatenate...", "  title=[YCC] keep image1=EnhancedLuminance image2=Cb image3=Cr image4=[-- None --]");
-                                IJ.run("YCbCr stack to RGB");
-                                WindowManager.getImage("YCC").close();
                                 noClobber(filePath+".jpg");
-                                IJ.saveAs("jpeg", filePath+".jpg");
+                                IJ.saveAs(RGBImage, "jpeg", filePath+".jpg");
                                 WindowManager.getImage(simpleImageName+".jpg").close();
                             } 
                             else if (csRtiDesired) {
-                                IJ.run("Concatenate...", "  title=[YCC] keep image1=Luminance image2=Cb image3=Cr image4=[-- None --]");
-                                IJ.run("YCbCr stack to RGB");
-                                WindowManager.getImage("YCC").close();
                                 noClobber(filePath+".jpg");
-                                IJ.saveAs("jpeg", filePath+".jpg");
+                                IJ.saveAs(RGBImage,"jpeg", filePath+".jpg");
                             }
-                            WindowManager.getImage("EnhancedLuminance").changes = false;
+                            enhancedLum.changes = false;
                             imp.changes = false;
-                            WindowManager.getImage("EnhancedLuminance").close();
+                            enhancedLum.flush();
+                            enhancedLum.close();
                             imp.flush();
+                            imp.close();
                         }
                     }
 		}
-                WindowManager.getImage("Cb").close();
-                WindowManager.getImage("Cr").close();
+                cb.flush();
+                cb.close();
+                cr.flush();
+                cr.close();
 		createLpFile(csProcessName, projectDirectory);
 		runFitter(csProcessName);
                 IJ.run("Collect Garbage");

--- a/src/main/java/com/slu/imagej/SpectralRTI_Toolkit.java
+++ b/src/main/java/com/slu/imagej/SpectralRTI_Toolkit.java
@@ -810,6 +810,7 @@ public class SpectralRTI_Toolkit implements Command {
                     }
                     //imglib2_img = ImagePlusAdapter.wrap( imp );
                     //ImageJFunctions.show(imglib2_img, "Preview");
+                    imp.setTitle("Preview");
                     imp.show();
                     dWait = new WaitForUserDialog("Select area", "Draw a rectangle containing the colors of interest for PCA then click OK\n(hint: limit to object or smaller)");
                     dWait.show();
@@ -1452,11 +1453,11 @@ public class SpectralRTI_Toolkit implements Command {
                 ImagePlus flNarrowNoGammaStack;
                 ImagePlus narrowNoGamma;
                 ImagePlus narrowKeptPCA = new ImagePlus();
+                IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" sort");
+                narrowNoGamma = WindowManager.getImage("Captures-Narrowband-NoGamma");
+                narrowNoGamma.hide();
 		//option to create new ones based on narrowband captures and assumption that pc1 and pc2 are best
 		if (pcaMethod.equals("Generate and select using defaults")){
-                    IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" sort");
-                    narrowNoGamma = WindowManager.getImage("Captures-Narrowband-NoGamma");
-                    narrowNoGamma.hide();
                     if (fluorescenceNoGamma.exists()) {
                         IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Fluorescence-NoGamma"+File.separator+" sort");
                         flNoGamma = WindowManager.getImage("Captures-Fluorescence-NoGamma");
@@ -1474,8 +1475,8 @@ public class SpectralRTI_Toolkit implements Command {
                     IJ.run(WindowManager.getImage("PCA of Captures-Narrowband-NoGamma"),"Slice Keeper", "first=2 last=3 increment=1");
                     WindowManager.getImage("Eigenvalue spectrum of Captures-Narrowband-NoGamma").close();
                     narrowNoGamma.changes = false;
-                    narrowNoGamma.flush();
-                    narrowNoGamma.close();
+//                    narrowNoGamma.flush();
+//                    narrowNoGamma.close();
                     WindowManager.getImage("PCA of Captures-Narrowband-NoGamma").close();
                     ImagePlus keptNoGammaPCA = WindowManager.getImage("PCA of Captures-Narrowband-NoGamma kept stack");
                     keptNoGammaPCA.hide();
@@ -1486,9 +1487,6 @@ public class SpectralRTI_Toolkit implements Command {
 		} 
                 else if (pcaMethod.equals("Generate and manually select two")) {
                     //option to create new ones and manually select (close all but two)
-                    IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Narrowband-NoGamma"+File.separator+" sort");
-                    narrowNoGamma = WindowManager.getImage("Captures-Narrowband-NoGamma");
-                    narrowNoGamma.hide();
                     if (fluorescenceNoGamma.exists()) {
                         IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Fluorescence-NoGamma"+File.separator+" sort");
                         flNoGamma = WindowManager.getImage("Captures-Fluorescence-NoGamma");
@@ -1501,24 +1499,22 @@ public class SpectralRTI_Toolkit implements Command {
                     else{
                         // ?
                     }
-                    IJ.run("PCA ");
                     narrowNoGamma.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
                     IJ.run(narrowNoGamma, "PCA ", "");
-                    IJ.run(WindowManager.getImage("PCA of Captures-Narrowband-NoGamma"),"Slice Keeper", "first=2 last=3 increment=1");
                     WindowManager.getImage("Eigenvalue spectrum of Captures-Narrowband-NoGamma").close();
                     narrowNoGamma.changes = false;
-                    narrowNoGamma.flush();
-                    narrowNoGamma.close();
+                    //narrowNoGamma.flush();
+                    //narrowNoGamma.close();
                     //WindowManager.getImage("PCA of Captures-Narrowband-NoGamma").close();
                     ImagePlus noGammaPCA = WindowManager.getImage("PCA of Captures-Narrowband-NoGamma");
                     noGammaPCA.show();
                     dWait = new WaitForUserDialog("Delete Slices", "Delete slices from the stack until two remain\n(Hint: Image > Stacks > Delete Slice)\nEnhance contrast as desired\nThen press Ok");
+                    dWait.show();
                     if(dWait.escPressed()){
                         //@userHitCancel
                         IJ.error("You must delete until there are two slices to continue!");
                         throw new Throwable("You must delete until there are two slices to continue!");
                     }
-                    dWait.show();
                     noGammaPCA.hide();
                     noGammaPCA.setTitle("PCA of Captures-Narrowband-NoGamma kept stack");
                     noGammaPCA.setRoi(pcaX,pcaY,pcaWidth,pcaHeight); 
@@ -1554,7 +1550,7 @@ public class SpectralRTI_Toolkit implements Command {
                 logService.log().info("Process Part 2");
 		if (psRakingDesired){
                     IJ.run("Image Sequence...", "open="+projectDirectory+"Captures-Hemisphere-Gamma"+File.separator);
-                    narrowNoGamma = WindowManager.getImage("Captures-Narrowband-NoGamma");
+                    narrowNoGamma = WindowManager.getImage("Captures-Hemisphere-Gamma");
                     narrowNoGamma.hide();
                     IJ.run(narrowNoGamma, "Z Project...", "projection=Median");
                     narrowNoGamma.changes = false;
@@ -1615,6 +1611,7 @@ public class SpectralRTI_Toolkit implements Command {
                         Files.deleteIfExists(toDelete.toPath());
                         transRGB.flush();
                         transNarrowKeptStack.flush();
+                        transNarrowKeptStack.close();
                         transRGB.close();
                     }
 		}
@@ -1653,7 +1650,6 @@ public class SpectralRTI_Toolkit implements Command {
                         RGBImg.hide();
                         if (listOfRakingDirections.get(i)) { //Yikes double check on this.  I believe it conrtols whether or not a StaticRaking file is created but doesn't rely on psrakingDesired.
                             //IJ.run("Concatenate...", "  title=[YCC] keep image1=EnhancedLuminance image2=[PCA of Captures-Narrowband-NoGamma kept stack] image3=[-- None --]");
-                            IJ.run(enhancedNarrowKeptStack, "YCbCr stack to RGB", "");
                             enhancedNarrowKeptStack.flush();
                             enhancedNarrowKeptStack.close();
                             positionNumber = IJ.pad(i+1, 2).toString();                          
@@ -1675,7 +1671,7 @@ public class SpectralRTI_Toolkit implements Command {
                             }
                             noClobber(filePath+".jpg");
                             IJ.saveAs(RGBImg, "jpeg", filePath+".jpg");
-                            WindowManager.getImage(simpleImageName+".jpg").close();
+                            //WindowManager.getImage(simpleImageName+".jpg").close();
                         } 
                         else if (psRtiDesired) {
                             extensionIndex = listOfHemisphereCaptures[i].getName().indexOf(".");
@@ -1689,7 +1685,7 @@ public class SpectralRTI_Toolkit implements Command {
                             }
                             noClobber(filePath+".jpg");
                             IJ.saveAs(RGBImg, "jpeg", filePath+".jpg");
-                            WindowManager.getImage(simpleImageName+".jpg").close();
+                            //WindowManager.getImage(simpleImageName+".jpg").close();
                         }
                         enhancedLum.changes = false;
                         imp.changes = false;


### PR DESCRIPTION
RAM and HD consolidation inside processing loops.  Images now hide in the interim.  You do see some windows flashing, this is because some ImageJ commands open images as part of their processing.  They are moved into the background at the earliest possible times.